### PR TITLE
Make standalone SpeakerView more independant from SpatGRIS and streamline SpatGRIS-started SpeakerView

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -33,10 +33,6 @@ window/size/viewport_width=800
 window/size/viewport_height=600
 window/subwindows/embed_subwindows=false
 
-[editor]
-
-run/main_run_args="-- launchedBySG=true"
-
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/debug_menu/plugin.cfg")

--- a/scenes/speakerview.tscn
+++ b/scenes/speakerview.tscn
@@ -652,6 +652,7 @@ layout_mode = 2
 text = "?"
 
 [node name="SettingsButton" type="Button" parent="UIOverlay"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(35.69, 0)
 layout_mode = 2
 
@@ -1119,6 +1120,7 @@ material_override = SubResource("StandardMaterial3D_0akp0")
 script = ExtResource("8_ntmpu")
 
 [node name="OSCServer" type="Node" parent="Network"]
+unique_name_in_owner = true
 script = ExtResource("14_7bw8e")
 
 [node name="Sources" type="Node" parent="."]

--- a/scripts/OSCServer.gd
+++ b/scripts/OSCServer.gd
@@ -17,21 +17,30 @@ extends Node
 var server = UDPServer.new()
 var peers: Array[PacketPeerUDP] = []
 
+## If active is false, this will not listen to OSC events.
+var active = true;
+
 signal speaker_message_received(address:String, value)
 signal source_message_received(address:String, value)
 signal control_message_received(address:String, value)
 
 func _ready():
+	if not active:
+		return
 	server.listen(port)
 	server.max_pending_connections = 10000000000000
 
 ## Sets the port for the server to listen on. Can only listen to one port at a time.
 func listen(new_port):
+	if not active:
+		return
 	server.stop()
 	port = new_port
 	server.listen(port)
 
 func _process(_delta):
+	if not active:
+		return
 	server.poll()
 	if server.is_connection_available():
 		var peer: PacketPeerUDP = server.take_connection()

--- a/scripts/SpeakerView.gd
+++ b/scripts/SpeakerView.gd
@@ -95,6 +95,9 @@ func _ready():
 	for arg in args:
 		if arg == "launchedBySG=true":
 			is_started_by_SG = true
+			# deactivate the settings if we are launched by SpatGRIS
+			%SettingsButton.visible = false
+			%OSCServer.active = false
 		elif arg == "firstLaunchBySG=true":
 			SV_started_by_SG_for_the_first_time = true
 		elif arg.contains("winPosition="):
@@ -259,15 +262,15 @@ func update_display():
 		old_speaker_setup_name = speaker_setup_name
 		get_viewport().set_title("SpeakerView " + app_version + " " + renderer + " - " + speaker_setup_name)
 
-	if SG_asked_to_kill_speakerview:
+	if is_started_by_SG and SG_asked_to_kill_speakerview:
 		get_tree().root.propagate_notification(NOTIFICATION_WM_CLOSE_REQUEST)
 
-	if SV_keep_on_top != SV_keep_on_top_last or SG_has_focus != SG_has_focus_last_focus:
+	if is_started_by_SG and (SV_keep_on_top != SV_keep_on_top_last or SG_has_focus != SG_has_focus_last_focus):
 		get_viewport().always_on_top = SV_keep_on_top and SG_has_focus
 		SG_has_focus_last_focus = SG_has_focus
 		SV_keep_on_top_last = SV_keep_on_top
 
-	if SV_should_grab_focus != SV_should_grab_focus_last:
+	if is_started_by_SG and SV_should_grab_focus != SV_should_grab_focus_last:
 		if SV_should_grab_focus:
 			get_window().grab_focus()
 		SV_should_grab_focus_last = SV_keep_on_top_last
@@ -276,7 +279,7 @@ func update_display():
 		draw_hall()
 		show_hall_last = show_hall
 
-	if should_move_SG_to_foreground:
+	if is_started_by_SG and should_move_SG_to_foreground:
 		SG_move_to_foreground()
 		should_move_SG_to_foreground = false
 


### PR DESCRIPTION
This irons out some of the kinks of SpeakerView when it is started independently.

When SpeakerView is started from SpatGRIS, this
- Disables the OSC server when SpeakerView is started from SpatGRIS
- Disables the networking options when SpeakerView is started from SpatGRIS

This makes it so users of SpatGRIS do not have to worry about external OSC messages messing up their SpeakerView and makes one less icon onscreen.

When SpeakerView is started independently, this makes it
- Ignore SpatGRIS's requests to shutdown
- Ignore SpatGRIS's requests to do windowing focus/order manipulations

This also changes the default way godot launches SpeakerView so that the standalone version is the default.