### PR TITLE
Adjust free camera right click behaviours

### DIFF
--- a/scripts/FreeCamera.gd
+++ b/scripts/FreeCamera.gd
@@ -6,10 +6,10 @@ const SHIFT_MULTIPLIER = 2.5
 const ALT_MULTIPLIER = 1.0 / SHIFT_MULTIPLIER
 
 
-@export_range(0.0, 1.0) var sensitivity: float = 0.25
+@export_range(0.0, 1.0) var sensitivity: float = 0.05
 
 # Mouse state
-var _mouse_position = Vector2(0.0, 0.0)
+var _mouse_impulse = Vector2(0.0, 0.0)
 var _total_pitch = 0.0
 
 # Movement state
@@ -36,7 +36,7 @@ var _wheel_impulse = 0
 
 func _ready():
 	look_at(Vector3(0.0, 1.0, 0.0), Vector3(0, 1, 0))
-	
+
 func reset_position():
 	global_position = Vector3(4,6,15.865)
 	look_at(Vector3(0.0, 1.0, 0.0), Vector3(0, 1, 0))
@@ -46,10 +46,11 @@ func _unhandled_input(event):
 		return
 	# Receives mouse motion
 	if event is InputEventMouseMotion:
-		if _left_click_pressed:
+		if _left_click_pressed and abs(event.relative[0])+abs(event.relative[0]) >=7.0:
+
 			Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
-		_mouse_position = event.relative
-	
+		_mouse_impulse += event.relative
+
 	# Receives mouse button input
 	if event is InputEventMouseButton:
 		match event.button_index:
@@ -89,7 +90,7 @@ func _unhandled_input(event):
 				_alt = event.pressed
 			KEY_R:
 				reset_position()
-				
+
 
 # Updates mouselook and movement every frame
 func _process(delta):
@@ -100,7 +101,7 @@ func _process(delta):
 func _update_movement(delta):
 	# Computes desired direction from key states
 	_direction = Vector3(
-		(_d as float) - (_a as float), 
+		(_d as float) - (_a as float),
 		(_e as float) - (_q as float),
 		(_s as float) - (_w as float)
 	)
@@ -108,23 +109,27 @@ func _update_movement(delta):
 	# The "drag" is a constant acceleration on the camera to bring it's velocity to 0
 	var offset = _direction.normalized() * _acceleration * _vel_multiplier * delta \
 		+ _velocity.normalized() * _deceleration * _vel_multiplier * delta
-	
+
 	offset.z += _wheel_impulse
 	_wheel_impulse *= 0.8
 	if abs(_wheel_impulse) < 0.1:
 		_wheel_impulse = 0
-	
+
 	if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED and _left_click_pressed:
-		_mouse_position *= sensitivity
-		offset.x += _mouse_position[0]
-		offset.y -= _mouse_position[1]
+		_mouse_impulse *= sensitivity
+		offset.x += _mouse_impulse[0]
+		offset.y -= _mouse_impulse[1]
+	_mouse_impulse *= 0.8
+
+	if abs(_mouse_impulse.length()) < 0.3:
+		_mouse_impulse = Vector2.ZERO
 	# Compute modifiers' speed multiplier
 	var speed_multi = 1
 	if _shift: speed_multi *= SHIFT_MULTIPLIER
 	if _alt: speed_multi *= ALT_MULTIPLIER
-	
+
 	# Checks if we should bother translating the camera
-	if (_direction == Vector3.ZERO and _wheel_impulse == 0 and not _left_click_pressed) and offset.length_squared() > _velocity.length_squared():
+	if (_direction == Vector3.ZERO and _wheel_impulse == 0 and _mouse_impulse == Vector2.ZERO) and offset.length_squared() > _velocity.length_squared():
 		# Sets the velocity to 0 to prevent jittering due to imperfect deceleration
 		_velocity = Vector3.ZERO
 	else:
@@ -132,21 +137,21 @@ func _update_movement(delta):
 		_velocity.x = clamp(_velocity.x + offset.x, -_vel_multiplier, _vel_multiplier)
 		_velocity.y = clamp(_velocity.y + offset.y, -_vel_multiplier, _vel_multiplier)
 		_velocity.z = clamp(_velocity.z + offset.z, -_vel_multiplier, _vel_multiplier)
-	
+
 		translate(_velocity * delta * speed_multi)
 
-# Updates mouse look 
+# Updates mouse look
 func _update_mouselook():
 	# Only rotates mouse if the mouse is captured
 	if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED and _right_click_pressed:
-		_mouse_position *= sensitivity
-		var yaw = _mouse_position.x
-		var pitch = _mouse_position.y
-		_mouse_position = Vector2(0, 0)
-		
+		_mouse_impulse *= sensitivity
+		var yaw = _mouse_impulse.x
+		var pitch = _mouse_impulse.y
+		_mouse_impulse = Vector2(0, 0)
+
 		# Prevents looking up/down too far
 		pitch = clamp(pitch, -90 - _total_pitch, 90 - _total_pitch)
 		_total_pitch += pitch
-	
+
 		rotate_y(deg_to_rad(-yaw))
 		rotate_object_local(Vector3(1,0,0), deg_to_rad(-pitch))


### PR DESCRIPTION
- Adds a "velocity" deadzone to prevent clicks with low amount of mouse drag from turning into drag motion. This mitigiates https://github.com/GRIS-UdeM/SpeakerView/issues/16
- Changes the left click physics code so that the screen doesn't always move even when the mouse doesn't