### PR TITLE
Fix a race condition where SpeakerView would sometimes overwrite SpatGRIS's display options

### DIFF
--- a/scripts/SpeakerView.gd
+++ b/scripts/SpeakerView.gd
@@ -283,9 +283,7 @@ func update_display():
 		SG_move_to_foreground()
 		should_move_SG_to_foreground = false
 
-	if !SV_has_received_SG_data_at_least_once:
-		network_node.send_UDP()
-		SV_has_received_SG_data_at_least_once = true
+	network_node.send_UDP()
 
 func render_spk_triplets():
 	var vertices = PackedVector3Array()


### PR DESCRIPTION
SpeakerView now waits for a valid SpatGRIS application state packet before starting to send its own udp packets to SpatGRIS.