### PR TITLE
Fix flickering bug

### DIFF
--- a/scripts/SpeakerView.gd
+++ b/scripts/SpeakerView.gd
@@ -283,7 +283,6 @@ func update_display():
 		SG_move_to_foreground()
 		should_move_SG_to_foreground = false
 
-	network_node.send_UDP()
 
 func render_spk_triplets():
 	var vertices = PackedVector3Array()


### PR DESCRIPTION
SpeakerView used to send its state every time it received anything from spatGRIS.

This caused a bug where settings would rapidly turn on and off.