### PR TITLE
Dynamically resize fulldome camera viewport and add antialiasing

### DIFF
--- a/addons/godot360/src/camera360.gd
+++ b/addons/godot360/src/camera360.gd
@@ -66,6 +66,17 @@ func set_dynamic_resize_callback():
 		dynamically_resize_subviewport = value
 		set_dynamic_resize_callback()
 
+func set_antialiasing(msaa_level: Viewport.MSAA):
+	if msaa_level != Viewport.MSAA_DISABLED:
+		for viewport in viewports:
+			viewport.msaa_3d = msaa_level
+			viewport.screen_space_aa = Viewport.SCREEN_SPACE_AA_FXAA
+	else:
+		for viewport in viewports:
+			viewport.msaa_3d = msaa_level
+			viewport.screen_space_aa = Viewport.SCREEN_SPACE_AA_DISABLED
+
+
 var viewports : Array[SubViewport] = []
 var cameras : Array[Camera3D] = []
 

--- a/scenes/speakerview.tscn
+++ b/scenes/speakerview.tscn
@@ -282,8 +282,11 @@ script = ExtResource("4_qw51s")
 fovx = 210.0
 lens = 7
 subviewport = NodePath("SubViewport")
+dynamically_resize_subviewport = true
 
 [node name="SubViewport" type="SubViewport" parent="Center/FulldomeCamera"]
+msaa_3d = 2
+screen_space_aa = 1
 
 [node name="cam_light" type="DirectionalLight3D" parent="Center/FulldomeCamera"]
 transform = Transform3D(1, 3.48787e-16, -3.48787e-16, 3.4878702e-16, -4.37114e-08, 1, 3.4878697e-16, -1, -4.37114e-08, 4, 15.8649, -6.0000005)

--- a/scenes/speakerview.tscn
+++ b/scenes/speakerview.tscn
@@ -285,7 +285,7 @@ subviewport = NodePath("SubViewport")
 dynamically_resize_subviewport = true
 
 [node name="SubViewport" type="SubViewport" parent="Center/FulldomeCamera"]
-msaa_3d = 2
+msaa_3d = 1
 screen_space_aa = 1
 
 [node name="cam_light" type="DirectionalLight3D" parent="Center/FulldomeCamera"]

--- a/scripts/SpeakerView.gd
+++ b/scripts/SpeakerView.gd
@@ -449,6 +449,7 @@ func set_SV_anti_aliasing(msaa: Viewport.MSAA) -> void:
 	get_viewport().set_msaa_3d(msaa)
 	anti_aliasing = get_viewport().get_msaa_3d()
 	DebugMenu.update_settings_label()
+	%FulldomeCamera.set_antialiasing(msaa)
 
 
 func _on_help_panel_button_pressed() -> void:


### PR DESCRIPTION
Makes it so the subviewports used by the fulldome camera follow the size of the main viewport instead of being a fixed 512x512. Also adds antialiasing to make the rendering a bit prettier.